### PR TITLE
Add config for channel retry delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You will need to use the Somfy myLink mobile app to configure the System ID and 
   "port": 44100,
   "reverseAll": false,
   "reverseChannels": [1, 2],
-  "hideChannels": [3, 4]
+  "hideChannels": [3, 4],
+  "channelRetryDelay": 5
 }
 ```

--- a/config.schema.json
+++ b/config.schema.json
@@ -44,6 +44,12 @@
           "maximum": 16,
           "step": 1
         }
+      },
+      "channelRetryDelay": {
+        "title": "Channel Retry Delay",
+        "type": "number",
+        "minimum": 5,
+        "description": "How long (in seconds) to wait before attempting to retry fetching channel info on failure"
       }
     },
     "required": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ export interface MyLinkPlatformConfig extends PlatformConfig {
   hideChannels?: number[]
   reverseChannels?: number[]
   reverseAll?: boolean
+  channelRetryDelay?: number
   debug?: boolean
 }
 

--- a/src/my-link.ts
+++ b/src/my-link.ts
@@ -190,7 +190,8 @@ export class MyLink {
   constructor(
     private systemID: string,
     private host: string,
-    private port = 44100
+    private port = 44100,
+    private channelRetryDelay = 5 // value is in seconds
   ) {}
 
   async getChannels(): Promise<Channel[]> {
@@ -205,7 +206,7 @@ export class MyLink {
       logError('Failed to get channels')
       logError(e.message)
 
-      await delay(5000)
+      await delay(this.channelRetryDelay * 1000) // convert seconds to ms
       return this.getChannels()
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -65,7 +65,7 @@ export class SomfyMyLinkPlatform implements DynamicPlatformPlugin {
       return
     }
 
-    const myLink = new MyLink(config.systemID, config.ipAddress, config.port),
+    const myLink = new MyLink(config.systemID, config.ipAddress, config.port, config.channelRetryDelay),
       channels = await myLink.getChannels(),
       { api } = this,
       cachedAccessoryIds = Object.keys(this.homebridgeAccessories),


### PR DESCRIPTION
There are times where I purposely take the myLink offline and don't want the plugin to constantly try fetching channel info. This adds a config parameter for users to specify how long to wait before retrying to fetch channel info.